### PR TITLE
Serialize errors in logs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import { createSyslogger, LoggerImpl } from './syslog';
 import { mkValidator } from './validator';
 import { prepareLog, Severity } from './prepare';
 
+export { serializeError } from './prepare';
+
 /**
  * The overloaded variants of logging.
  */

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -79,18 +79,14 @@ const isPrimitive = (val: any) =>
     ['number', 'string', 'boolean'].includes(typeof val);
 
 /** Serialize and Error to a plain object, keeping commonly used properties. */
-export const serializeError = (
-    err: Error
-): SerializedError =>
-    ['name', 'message', 'stack']    // Wanted properties from Error
-        .filter(prop => isPrimitive((err as any)[prop]))
-        .reduce(
-            (acc, prop: keyof Error) => ({
-                ...acc,
-                [prop]: err[prop],
-            }),
-            {} as SerializedError
-        );
+export const serializeError = (err: Error): SerializedError => ({
+    ...Object.assign.apply(null, (['name', 'message', 'stack']
+        // Filter out unwanted
+        .filter(k => isPrimitive((err as any)[k]))
+        // Create new object array and spread the array on the return object
+        .map((k: keyof Error) => ({ [k]: err[k] })))
+    ),
+});
 
 /** Recursive helper to remove complex objects. */
 // TODO fix for cyclic deps?

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -79,14 +79,13 @@ const isPrimitive = (val: any) =>
     ['number', 'string', 'boolean'].includes(typeof val);
 
 /** Serialize and Error to a plain object, keeping commonly used properties. */
-export const serializeError = (err: Error): SerializedError => ({
-    ...Object.assign.apply(null, (['name', 'message', 'stack']
+export const serializeError = (err: Error): SerializedError =>
+    Object.assign.apply(null, (['name', 'message', 'stack']
         // Filter out unwanted
         .filter(k => isPrimitive((err as any)[k]))
         // Create new object array and spread the array on the return object
         .map((k: keyof Error) => ({ [k]: err[k] })))
-    ),
-});
+    );
 
 /** Recursive helper to remove complex objects. */
 // TODO fix for cyclic deps?

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -76,9 +76,7 @@ interface SerializedError {
 }
 
 const isPrimitive = (val: any) =>
-    typeof val === 'number' ||
-    typeof val === 'string' ||
-    typeof val === 'boolean';
+    ['number', 'string', 'boolean'].includes(typeof val);
 
 /** Serialize and Error to a plain object, keeping commonly used properties. */
 export const serializeError = (

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -69,7 +69,7 @@ export const prepareLog = (
     };
 };
 
-interface SerializedError {
+export interface SerializedError {
     name: string;
     message: string;
     stack?: string;
@@ -82,14 +82,13 @@ const isPrimitive = (val: any) =>
 export const serializeError = (
     err: Error
 ): SerializedError =>
-    ['name', 'message', 'stack']
+    ['name', 'message', 'stack']    // Wanted properties from Error
         .filter(prop => isPrimitive((err as any)[prop]))
         .reduce(
-            (acc, prop: keyof Error) => {
-                return {
+            (acc, prop: keyof Error) => ({
                 ...acc,
                 [prop]: err[prop],
-            };},
+            }),
             {} as SerializedError
         );
 

--- a/test/test-filter-unwant.ts
+++ b/test/test-filter-unwant.ts
@@ -21,4 +21,9 @@ test('filterUnwanted', t => {
     t.deepEqual(filterUnwanted([1, {}]), [1, {}]);
     t.deepEqual(filterUnwanted([1, { k: 42 }]), [1, { k: 42 }]);
     t.deepEqual(filterUnwanted([1, { k: 42, j: undefined }]), [1, { k: 42 }]);
+
+    const err = filterUnwanted({ cause: new Error('Msg') });
+    t.is(err.cause.name, 'Error');
+    t.is(err.cause.message, 'Msg');
+    t.is(typeof err.cause.stack, 'string');
 });

--- a/test/test-serialize-error.ts
+++ b/test/test-serialize-error.ts
@@ -1,0 +1,9 @@
+import test from 'ava';
+import { serializeError } from '../src';
+
+test('serializeError', t => {
+    const serialized = serializeError(new Error('Foo'));
+    t.is(serialized.message, 'Foo');
+    t.is(serialized.name, 'Error');
+    t.is(typeof serialized.stack, 'string');
+});


### PR DESCRIPTION
This patch makes `Error` in log data serialize well into objects.

Future work could include whitelisting certain custom error props to keep. Now we keep `['name', 'message', 'stack']`.
