### PR TITLE
Update None compliance docs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -161,8 +161,8 @@ export enum Compliance {
     Mid = 'mid',
 
     /**
-     * For services that have just been converted. Nothing is forwarded to our log web UI.
-     * They are available via SSH on the log ingester.
+     * For services that have just been converted. Logs are forwarded to our log web UI
+     * and treated as plain text messages.
      *
      * Use syslog facility `local2`
      */


### PR DESCRIPTION
Per Andoma's update here: https://wearelookback.slack.com/archives/C04NYK48Q/p1579291646051000 this is no longer accurate and should be modified to note that logs will still go to logUI.