### PR TITLE
Add invitationId

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,11 @@ export interface WellKnown {
     teamId?: string;
 
     /**
+     * Invitation id.
+     */
+    invitationId?: string;
+
+    /**
      * Ip address of user in question. Be very restrictive with logging this.
      */
     userIp?: string;

--- a/src/is-well-known.ts
+++ b/src/is-well-known.ts
@@ -8,6 +8,7 @@ const WellKnown: { [k: string]: 'string' | 'number' | 'boolean' } = {
     recordingId: 'string',
     userId: 'string',
     teamId: 'string',
+    invitationId: 'string',
     userIp: 'string',
     sessionId: 'string',
     metricGroup: 'string',


### PR DESCRIPTION
I need support for invitationIds in the `wellKnown` data for logging purposes.

https://app.clubhouse.io/lookback/story/74678/fix-herald-email-invite-failures